### PR TITLE
docs: add todo for Supabase Data API GRANT statements

### DIFF
--- a/.claude/todo.md
+++ b/.claude/todo.md
@@ -3,5 +3,6 @@
 ## Open
 
 - Centralize Supabase URL — `js/config.js`, `tests/helpers/global-setup.js`, `tests/helpers/fixtures.js`, and `tests/security.spec.js` all hardcode it independently. Pull from env var so there's one place to update.
+- Add explicit GRANT statements for Supabase Data API change (enforced Oct 30, 2026) — new migration needed with `grant select, update on public.profiles to authenticated`, `grant select, insert, update, delete on public.movements to authenticated`, and `grant select, insert, update, delete on public.tags to authenticated`. Without this, PostgREST returns 42501 errors. See `supabase/migrations/20260221000000_initial_schema.sql`.
 
 ## Done


### PR DESCRIPTION
## Summary
Updated the project todo list to document a required migration for Supabase Data API compliance changes taking effect October 30, 2026.

## Changes
- Added todo item documenting the need for explicit GRANT statements on `public.profiles`, `public.movements`, and `public.tags` tables for the `authenticated` role
- Noted that PostgREST returns 42501 errors without these permissions
- Referenced the initial schema migration file as the location for implementation

## Details
This is a documentation-only change capturing a known requirement for a future database migration. The GRANT statements will need to be added to ensure proper access control for authenticated users once Supabase enforces stricter permission requirements.

https://claude.ai/code/session_01PB4ZVTjZLybf5gkrg4tprg